### PR TITLE
bOrientRotationToMovement allows the update of the rotation in SetDis…

### DIFF
--- a/Source/SplineFollow/Private/Components/SFSplineFollowingMovementComponent.cpp
+++ b/Source/SplineFollow/Private/Components/SFSplineFollowingMovementComponent.cpp
@@ -599,6 +599,14 @@ void USFSplineFollowingMovementComponent::SetDistanceOnSplineInternal( const flo
     const auto spline_location_at_distance = FollowedSplineComponent->GetLocationAtDistanceAlongSpline( distance_on_spline, ESplineCoordinateSpace::World );
 
     UpdatedComponent->SetWorldLocation( spline_location_at_distance );
+
+    if ( bOrientRotationToMovement )
+    {
+        const auto spline_rotation_at_distance = FollowedSplineComponent->GetRotationAtDistanceAlongSpline( distance_on_spline, ESplineCoordinateSpace::World );
+
+        UpdatedComponent->SetWorldRotation( spline_rotation_at_distance );
+    }
+
     DistanceOnSpline = distance_on_spline;
     NormalizedDistanceOnSpline = DistanceOnSpline / FollowedSplineComponent->GetSplineLength();
 }


### PR DESCRIPTION
I've used the boolean from the base class to detect if we should update or not the rotation. If we see side-effects with that, we could update the functions with a boolean parameter.