### PR TITLE
fix_marker_processing

### DIFF
--- a/Source/SplineFollow/Private/Components/SFSplineFollowingMovementComponent.cpp
+++ b/Source/SplineFollow/Private/Components/SFSplineFollowingMovementComponent.cpp
@@ -411,6 +411,12 @@ void USFSplineFollowingMovementComponent::ResetMarkersUsage()
     SplineMarkerProcessor.Reset();
 }
 
+void USFSplineFollowingMovementComponent::SetInvertSpeed( bool invert )
+{
+    bInvertSpeed = invert;
+    SplineMarkerProcessor.SetUpdateLastProcessedMarker( true );
+}
+
 void USFSplineFollowingMovementComponent::RegisterPositionObserver( const FSWOnSplineFollowingReachedPositionDelegate & delegate, float normalized_position, bool trigger_once /*= true*/ )
 {
     FPositionObserver observer;

--- a/Source/SplineFollow/Private/Components/SFSplineFollowingTypes.cpp
+++ b/Source/SplineFollow/Private/Components/SFSplineFollowingTypes.cpp
@@ -108,58 +108,48 @@ void FSFSplineMarkerProcessor::ProcessSplineMarkers( const float distance_on_spl
         return;
     }
 
-    if ( const auto * spline_component = Cast< USFSplineComponent >( SplineComponent ) )
+    const auto * spline_component = Cast< USFSplineComponent >( SplineComponent );
+    if ( spline_component == nullptr )
     {
-        const auto & spline_marker_proxies = spline_component->GetSplineMarkerProxies();
-        const auto spline_length = spline_component->GetSplineLength();
-
-        if ( current_speed > 0.0f )
-        {
-            const auto first_index = LastProcessedMarkerIndex == INDEX_NONE
-                                         ? 0
-                                         : LastProcessedMarkerIndex + 1;
-
-            for ( auto index = first_index; index < spline_marker_proxies.Num(); ++index )
-            {
-                const auto & marker_proxy = spline_marker_proxies[ index ];
-                const auto marker_distance = spline_length * marker_proxy.SplineNormalizedDistance;
-
-                if ( distance_on_spline >= marker_distance )
-                {
-                    // Call the function after as it may attach the actor on another spline. this would reset LastProcessedMarkerIndex, but we would override the value after
-                    LastProcessedMarkerIndex = index;
-                    marker_proxy.Function( owner );
-                }
-            }
-        }
-        else
-        {
-            const auto first_index = LastProcessedMarkerIndex == INDEX_NONE
-                                         ? spline_marker_proxies.Num() - 1
-                                         : LastProcessedMarkerIndex - 1;
-
-            for ( auto index = first_index; index >= 0; --index )
-            {
-                const auto & marker_proxy = spline_marker_proxies[ index ];
-                const auto marker_distance = spline_length * marker_proxy.SplineNormalizedDistance;
-
-                if ( distance_on_spline <= marker_distance )
-                {
-                    // Call the function after as it may attach the actor on another spline. this would reset LastProcessedMarkerIndex, but we would override the value after
-                    LastProcessedMarkerIndex = index;
-                    marker_proxy.Function( owner );
-                }
-            }
-        }
+        return;
     }
-}
 
-void FSFSplineMarkerProcessor::TryUpdateLastProcessedMarker( const float distance_on_spline, const float current_speed )
-{
-    if ( bUpdateLastProcessedMarker && current_speed != 0.0f )
+    const auto & spline_marker_proxies = spline_component->GetSplineMarkerProxies();
+    const auto spline_length = spline_component->GetSplineLength();
+
+    int first_index;
+
+    if ( current_speed > 0.0f )
     {
-        UpdateLastProcessedMarker( distance_on_spline, current_speed );
-        bUpdateLastProcessedMarker = false;
+        first_index = LastProcessedMarkerIndex == INDEX_NONE
+                          ? 0
+                          : LastProcessedMarkerIndex + 1;
+    }
+    else
+    {
+        first_index = LastProcessedMarkerIndex == INDEX_NONE
+                          ? spline_marker_proxies.Num() - 1
+                          : LastProcessedMarkerIndex - 1;
+    }
+
+    const auto step = current_speed > 0.0f ? 1 : -1;
+
+    for ( auto index = first_index; index >= 0 && index < spline_marker_proxies.Num(); index += step )
+    {
+        const auto & marker_proxy = spline_marker_proxies[ index ];
+        const auto marker_distance = spline_length * marker_proxy.SplineNormalizedDistance;
+
+        if ( distance_on_spline * step >= marker_distance * step )
+        {
+            // Call the function after as it may attach the actor on another spline.
+            // This would reset LastProcessedMarkerIndex, but we would override the value after
+            LastProcessedMarkerIndex = index;
+            marker_proxy.Function( owner );
+
+            continue;
+        }
+
+        break;
     }
 }
 
@@ -183,12 +173,28 @@ void FSFSplineMarkerProcessor::UpdateLastProcessedMarker( const float distance_o
         const auto & marker_proxy = spline_marker_proxies[ index ];
         const auto marker_distance = spline_length * marker_proxy.SplineNormalizedDistance;
 
-        if ( marker_distance * check_multiplier > distance_on_spline * check_multiplier )
+        if ( marker_distance * check_multiplier <= distance_on_spline * check_multiplier )
+        {
+            LastProcessedMarkerIndex = index;
+
+            if ( check_multiplier < 0.0f )
+            {
+                break;
+            }
+        }
+        else if ( check_multiplier > 0.0f )
         {
             break;
         }
+    }
+}
 
-        LastProcessedMarkerIndex = index;
+void FSFSplineMarkerProcessor::TryUpdateLastProcessedMarker( const float distance_on_spline, const float current_speed )
+{
+    if ( bUpdateLastProcessedMarker && current_speed != 0.0f )
+    {
+        UpdateLastProcessedMarker( distance_on_spline, current_speed );
+        bUpdateLastProcessedMarker = false;
     }
 }
 

--- a/Source/SplineFollow/Public/Components/SFSplineFollowingMovementComponent.h
+++ b/Source/SplineFollow/Public/Components/SFSplineFollowingMovementComponent.h
@@ -83,6 +83,9 @@ public:
     UFUNCTION( BlueprintCallable )
     void ResetMarkersUsage();
 
+    UFUNCTION( BlueprintCallable )
+    void SetInvertSpeed( bool invert );
+
     void RegisterPositionObserver( const FSWOnSplineFollowingReachedPositionDelegate & delegate, float normalized_position, bool trigger_once = true );
 
 #if WITH_EDITOR
@@ -181,7 +184,7 @@ private:
     UPROPERTY( BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
     TObjectPtr< USFSplineSpeedProvider > SpeedProvider;
 
-    UPROPERTY( EditAnywhere, BlueprintReadWrite, meta = ( AllowPrivateAccess = true ) )
+    UPROPERTY( EditAnywhere, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
     uint8 bInvertSpeed : 1;
 
     UPROPERTY( VisibleInstanceOnly, BlueprintReadWrite, meta = ( AllowPrivateAccess = true ) )

--- a/Source/SplineFollow/Public/Components/SFSplineFollowingTypes.h
+++ b/Source/SplineFollow/Public/Components/SFSplineFollowingTypes.h
@@ -96,9 +96,15 @@ public:
     void TryUpdateLastProcessedMarker( const float distance_on_spline, const float current_speed );
     void UpdateLastProcessedMarker( const float distance_on_spline, const float current_speed );
     void Reset();
+    void SetUpdateLastProcessedMarker( bool update );
 
 private:
     TObjectPtr< USplineComponent > SplineComponent;
     int LastProcessedMarkerIndex;
     uint8 bUpdateLastProcessedMarker : 1;
 };
+
+FORCEINLINE void FSFSplineMarkerProcessor::SetUpdateLastProcessedMarker( const bool update )
+{
+    bUpdateLastProcessedMarker = update;
+}


### PR DESCRIPTION
Markers were processed wrong sometimes, for example when invert speed was set to true during gameplay. This resolves the issues with the LastUpdatedMarkerIndex being wrong or not being updated when it was needed.